### PR TITLE
Feature/rootcbv to pushconstant

### DIFF
--- a/tf/shaders/basic.vert.fsl
+++ b/tf/shaders/basic.vert.fsl
@@ -6,7 +6,7 @@ STRUCT(VSOutput)
     DATA(float, aTreshold, COLOR1);
 };
 
-PUSH_CONSTANT(uRootConstants, b0)
+PUSH_CONSTANT(uRootConstants, b1)
 {
     DATA(float2, offset, None);
     DATA(float2, scale, None);

--- a/tf/shaders/basic.vert.fsl
+++ b/tf/shaders/basic.vert.fsl
@@ -6,7 +6,7 @@ STRUCT(VSOutput)
     DATA(float, aTreshold, COLOR1);
 };
 
-CBUFFER(imageTransform_rootcbv, UPDATE_FREQ_PER_DRAW, b0, binding = 0)
+PUSH_CONSTANT(uRootConstants, b0)
 {
     DATA(float2, offset, None);
     DATA(float2, scale, None);

--- a/tf/shaders/basic.vert.fsl
+++ b/tf/shaders/basic.vert.fsl
@@ -6,7 +6,7 @@ STRUCT(VSOutput)
     DATA(float, aTreshold, COLOR1);
 };
 
-PUSH_CONSTANT(uRootConstants, b1)
+PUSH_CONSTANT(rootconstant_small, b1)
 {
     DATA(float2, offset, None);
     DATA(float2, scale, None);

--- a/tf/shaders/basic_color_quad.vert.fsl
+++ b/tf/shaders/basic_color_quad.vert.fsl
@@ -4,7 +4,7 @@ STRUCT(VSOutput)
 	DATA(float4, color,    COLOR);
 };
 
-PUSH_CONSTANT(uRootConstants, b1)
+PUSH_CONSTANT(rootconstant_small, b1)
 {
     DATA(float2, offset, None);
     DATA(float2, scale, None);

--- a/tf/shaders/basic_color_quad.vert.fsl
+++ b/tf/shaders/basic_color_quad.vert.fsl
@@ -4,7 +4,7 @@ STRUCT(VSOutput)
 	DATA(float4, color,    COLOR);
 };
 
-CBUFFER(imageTransform_rootcbv, UPDATE_FREQ_PER_DRAW, b0, binding = 0)
+PUSH_CONSTANT(uRootConstants, b0)
 {
     DATA(float2, offset, None);
     DATA(float2, scale, None);

--- a/tf/shaders/basic_color_quad.vert.fsl
+++ b/tf/shaders/basic_color_quad.vert.fsl
@@ -4,7 +4,7 @@ STRUCT(VSOutput)
 	DATA(float4, color,    COLOR);
 };
 
-PUSH_CONSTANT(uRootConstants, b0)
+PUSH_CONSTANT(uRootConstants, b1)
 {
     DATA(float2, offset, None);
     DATA(float2, scale, None);

--- a/tf/shaders/beam.vert.fsl
+++ b/tf/shaders/beam.vert.fsl
@@ -8,7 +8,7 @@ CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b0, binding = 0)
     DATA(float4x4, vpMatrix, None);
 };
 
-PUSH_CONSTANT(uRootConstants, b1)
+PUSH_CONSTANT(rootconstant_small, b1)
 {
     DATA(float4, color, None);
     DATA(float4, pad, None);

--- a/tf/shaders/beam.vert.fsl
+++ b/tf/shaders/beam.vert.fsl
@@ -8,7 +8,7 @@ CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b1, binding = 1)
     DATA(float4x4, vpMatrix, None);
 };
 
-CBUFFER(UniformBufferObject_rootcbv, UPDATE_FREQ_PER_DRAW, b0, binding = 0)
+PUSH_CONSTANT(uRootConstants, b0)
 {
     DATA(float4, color, None);
 };

--- a/tf/shaders/beam.vert.fsl
+++ b/tf/shaders/beam.vert.fsl
@@ -3,14 +3,15 @@ STRUCT(VSInput)
 	DATA(float3, inVertex, POSITION);
 };
 
-CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b1, binding = 1)
+CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b0, binding = 0)
 {
     DATA(float4x4, vpMatrix, None);
 };
 
-PUSH_CONSTANT(uRootConstants, b0)
+PUSH_CONSTANT(uRootConstants, b1)
 {
     DATA(float4, color, None);
+    DATA(float4, pad, None);
 };
 
 STRUCT(VSOutput)

--- a/tf/shaders/d_light.vert.fsl
+++ b/tf/shaders/d_light.vert.fsl
@@ -4,9 +4,9 @@ STRUCT(VSInput)
     DATA(float3, inColor, COLOR);
 };
 
-CBUFFER(UniformBufferObject_rootcbv, UPDATE_FREQ_PER_DRAW, b0, binding = 0)
+CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_DRAW, b0, binding = 0)
 {
-    DATA(float4x4, mvpMatrix, None);
+    DATA(float4x4, vpMatrix, None);
 };
 
 STRUCT(VSOutput)
@@ -20,7 +20,7 @@ VSOutput VS_MAIN( VSInput In, SV_InstanceID(uint) InstanceID )
     INIT_MAIN;
     VSOutput Out;
 
-    Out.position = mul(Get(mvpMatrix), float4(In.inVertex, 1.0));
+    Out.position = mul(Get(vpMatrix), float4(In.inVertex, 1.0));
     Out.color = float4(In.inColor, 1.0);
 
     RETURN(Out);

--- a/tf/shaders/d_light.vert.fsl
+++ b/tf/shaders/d_light.vert.fsl
@@ -4,7 +4,7 @@ STRUCT(VSInput)
     DATA(float3, inColor, COLOR);
 };
 
-CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b1, binding = 1)
+CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b0, binding = 0)
 {
     DATA(float4x4, vpMatrix, None);
 };

--- a/tf/shaders/d_light.vert.fsl
+++ b/tf/shaders/d_light.vert.fsl
@@ -4,7 +4,7 @@ STRUCT(VSInput)
     DATA(float3, inColor, COLOR);
 };
 
-CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_DRAW, b0, binding = 0)
+CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b1, binding = 1)
 {
     DATA(float4x4, vpMatrix, None);
 };

--- a/tf/shaders/model.vert.fsl
+++ b/tf/shaders/model.vert.fsl
@@ -1,4 +1,4 @@
-CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b1, binding = 1)
+CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b0, binding = 0)
 {
     DATA(float4x4, vpMatrix, None);
 };

--- a/tf/shaders/model.vert.fsl
+++ b/tf/shaders/model.vert.fsl
@@ -3,7 +3,7 @@ CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b0, binding = 0)
     DATA(float4x4, vpMatrix, None);
 };
 
-PUSH_CONSTANT(rootconstant_model, b2)
+PUSH_CONSTANT(rootconstant_large, b2)
 {
     DATA(float4x4, model, None);
     DATA(float, textured, None);

--- a/tf/shaders/model.vert.fsl
+++ b/tf/shaders/model.vert.fsl
@@ -3,7 +3,7 @@ CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b1, binding = 1)
     DATA(float4x4, vpMatrix, None);
 };
 
-PUSH_CONSTANT(uRootConstants, b0)
+PUSH_CONSTANT(rootconstant_model, b2)
 {
     DATA(float4x4, model, None);
     DATA(float, textured, None);

--- a/tf/shaders/model.vert.fsl
+++ b/tf/shaders/model.vert.fsl
@@ -3,7 +3,7 @@ CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b1, binding = 1)
     DATA(float4x4, vpMatrix, None);
 };
 
-CBUFFER(UniformBufferObject_rootcbv, UPDATE_FREQ_PER_DRAW, b0, binding = 0)
+PUSH_CONSTANT(uRootConstants, b0)
 {
     DATA(float4x4, model, None);
     DATA(float, textured, None);

--- a/tf/shaders/nullmodel.vert.fsl
+++ b/tf/shaders/nullmodel.vert.fsl
@@ -3,7 +3,7 @@ CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b1, binding = 1)
     DATA(float4x4, vpMatrix, None);
 };
 
-CBUFFER(UniformBufferObject_rootcbv, UPDATE_FREQ_PER_DRAW, b0, binding = 0)
+PUSH_CONSTANT(uRootConstants, b0)
 {
     DATA(float4x4, model, None);
 };

--- a/tf/shaders/nullmodel.vert.fsl
+++ b/tf/shaders/nullmodel.vert.fsl
@@ -1,4 +1,4 @@
-CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b1, binding = 1)
+CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b0, binding = 0)
 {
     DATA(float4x4, vpMatrix, None);
 };

--- a/tf/shaders/nullmodel.vert.fsl
+++ b/tf/shaders/nullmodel.vert.fsl
@@ -3,7 +3,7 @@ CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b0, binding = 0)
     DATA(float4x4, vpMatrix, None);
 };
 
-PUSH_CONSTANT(rootconstant_model, b2)
+PUSH_CONSTANT(rootconstant_large, b2)
 {
     DATA(float4x4, model, None);
     DATA(float, textured, None);

--- a/tf/shaders/nullmodel.vert.fsl
+++ b/tf/shaders/nullmodel.vert.fsl
@@ -3,9 +3,10 @@ CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b1, binding = 1)
     DATA(float4x4, vpMatrix, None);
 };
 
-PUSH_CONSTANT(uRootConstants, b0)
+PUSH_CONSTANT(rootconstant_model, b2)
 {
     DATA(float4x4, model, None);
+    DATA(float, textured, None);
 };
 
 STRUCT(VSInput)

--- a/tf/shaders/particle.vert.fsl
+++ b/tf/shaders/particle.vert.fsl
@@ -5,7 +5,7 @@ STRUCT(VSInput)
     DATA(float2, inTexCoord, TEXCOORD0);
 };
 
-CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b1, binding = 1)
+CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b0, binding = 0)
 {
     DATA(float4x4, vpMatrix, None);
 };

--- a/tf/shaders/point_particle.vert.fsl
+++ b/tf/shaders/point_particle.vert.fsl
@@ -9,7 +9,7 @@ CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b0, binding = 0)
     DATA(float4x4, vpMatrix, None);
 };
 
-PUSH_CONSTANT(uRootConstants, b1)
+PUSH_CONSTANT(rootconstant_small, b1)
 {
     DATA(float, pointSize, None);
     DATA(float, pointScale, None);

--- a/tf/shaders/point_particle.vert.fsl
+++ b/tf/shaders/point_particle.vert.fsl
@@ -9,7 +9,7 @@ CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b1, binding = 1)
     DATA(float4x4, vpMatrix, None);
 };
 
-CBUFFER(UniformBufferObject_rootcbv, UPDATE_FREQ_PER_DRAW, b0, binding = 0)
+PUSH_CONSTANT(uRootConstants, b0)
 {
     DATA(float, pointSize, None);
     DATA(float, pointScale, None);

--- a/tf/shaders/point_particle.vert.fsl
+++ b/tf/shaders/point_particle.vert.fsl
@@ -4,12 +4,12 @@ STRUCT(VSInput)
     DATA(float4, inColor, COLOR);
 };
 
-CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b1, binding = 1)
+CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b0, binding = 0)
 {
     DATA(float4x4, vpMatrix, None);
 };
 
-PUSH_CONSTANT(uRootConstants, b0)
+PUSH_CONSTANT(uRootConstants, b1)
 {
     DATA(float, pointSize, None);
     DATA(float, pointScale, None);

--- a/tf/shaders/polygon.vert.fsl
+++ b/tf/shaders/polygon.vert.fsl
@@ -9,7 +9,7 @@ CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b1, binding = 1)
     DATA(float4x4, vpMatrix, None);
 };
 
-CBUFFER(UniformBufferObject_rootcbv, UPDATE_FREQ_PER_DRAW, b0, binding = 0)
+PUSH_CONSTANT(uRootConstants, b0)
 {
     DATA(float4, color, None);
 };

--- a/tf/shaders/polygon.vert.fsl
+++ b/tf/shaders/polygon.vert.fsl
@@ -9,7 +9,7 @@ CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b0, binding = 0)
     DATA(float4x4, vpMatrix, None);
 };
 
-PUSH_CONSTANT(uRootConstants, b1)
+PUSH_CONSTANT(rootconstant_small, b1)
 {
     DATA(float4, color, None);
     DATA(float4, pad, None);

--- a/tf/shaders/polygon.vert.fsl
+++ b/tf/shaders/polygon.vert.fsl
@@ -4,14 +4,15 @@ STRUCT(VSInput)
     DATA(float2, inTexCoord, TEXCOORD0);
 };
 
-CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b1, binding = 1)
+CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b0, binding = 0)
 {
     DATA(float4x4, vpMatrix, None);
 };
 
-PUSH_CONSTANT(uRootConstants, b0)
+PUSH_CONSTANT(uRootConstants, b1)
 {
     DATA(float4, color, None);
+    DATA(float4, pad, None);
 };
 
 STRUCT(VSOutput)

--- a/tf/shaders/polygon_lmap.vert.fsl
+++ b/tf/shaders/polygon_lmap.vert.fsl
@@ -10,7 +10,7 @@ CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b1, binding = 1)
     DATA(float4x4, vpMatrix, None);
 };
 
-PUSH_CONSTANT(uRootConstants, b0)
+PUSH_CONSTANT(rootconstant_model, b2)
 {
     DATA(float4x4, model, None);
     DATA(float, viewLightmaps, None);

--- a/tf/shaders/polygon_lmap.vert.fsl
+++ b/tf/shaders/polygon_lmap.vert.fsl
@@ -10,7 +10,7 @@ CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b1, binding = 1)
     DATA(float4x4, vpMatrix, None);
 };
 
-CBUFFER(UniformBufferObject_rootcbv, UPDATE_FREQ_PER_DRAW, b0, binding = 0)
+PUSH_CONSTANT(uRootConstants, b0)
 {
     DATA(float4x4, model, None);
     DATA(float, viewLightmaps, None);

--- a/tf/shaders/polygon_lmap.vert.fsl
+++ b/tf/shaders/polygon_lmap.vert.fsl
@@ -5,7 +5,7 @@ STRUCT(VSInput)
     DATA(float2, inTexCoordLmap, TEXCOORD1);
 };
 
-CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b1, binding = 1)
+CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b0, binding = 0)
 {
     DATA(float4x4, vpMatrix, None);
 };

--- a/tf/shaders/polygon_lmap.vert.fsl
+++ b/tf/shaders/polygon_lmap.vert.fsl
@@ -10,7 +10,7 @@ CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b0, binding = 0)
     DATA(float4x4, vpMatrix, None);
 };
 
-PUSH_CONSTANT(rootconstant_model, b2)
+PUSH_CONSTANT(rootconstant_large, b2)
 {
     DATA(float4x4, model, None);
     DATA(float, viewLightmaps, None);

--- a/tf/shaders/polygon_warp.vert.fsl
+++ b/tf/shaders/polygon_warp.vert.fsl
@@ -4,12 +4,12 @@ STRUCT(VSInput)
     DATA(float2, inTexCoord, TEXCOORD0);
 };
 
-CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b1, binding = 1)
+CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b0, binding = 0)
 {
     DATA(float4x4, vpMatrix, None);
 };
 
-PUSH_CONSTANT(uRootConstants, b0)
+PUSH_CONSTANT(rootconstant_polygonwarp, b3)
 {
     DATA(float4x4, model, None);
     DATA(float4, color, None);

--- a/tf/shaders/polygon_warp.vert.fsl
+++ b/tf/shaders/polygon_warp.vert.fsl
@@ -9,7 +9,7 @@ CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b1, binding = 1)
     DATA(float4x4, vpMatrix, None);
 };
 
-CBUFFER(UniformBufferObject_rootcbv, UPDATE_FREQ_PER_DRAW, b0, binding = 0)
+PUSH_CONSTANT(uRootConstants, b0)
 {
     DATA(float4x4, model, None);
     DATA(float4, color, None);

--- a/tf/shaders/postprocess.frag.fsl
+++ b/tf/shaders/postprocess.frag.fsl
@@ -1,7 +1,9 @@
-PUSH_CONSTANT(PushConstant, b1)
+PUSH_CONSTANT(uRootConstants, b1)
 {
 	DATA(float, postprocess, None);
 	DATA(float, gamma, None);
+	DATA(float2, pad1, None);
+	DATA(float4, pad2, None);
 };
 
 RES(Tex2D(float4), sTexture, UPDATE_FREQ_NONE, t1, binding = 1);

--- a/tf/shaders/postprocess.frag.fsl
+++ b/tf/shaders/postprocess.frag.fsl
@@ -1,4 +1,4 @@
-PUSH_CONSTANT(uRootConstants, b1)
+PUSH_CONSTANT(rootconstant_small, b1)
 {
 	DATA(float, postprocess, None);
 	DATA(float, gamma, None);

--- a/tf/shaders/shadows.vert.fsl
+++ b/tf/shaders/shadows.vert.fsl
@@ -8,7 +8,7 @@ CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b1, binding = 1)
     DATA(float4x4, vpMatrix, None);
 };
 
-CBUFFER(UniformBufferObject_rootcbv, UPDATE_FREQ_PER_DRAW, b0, binding = 0)
+PUSH_CONSTANT(uRootConstants, b0)
 {
     DATA(float4x4, model, None);
 };

--- a/tf/shaders/shadows.vert.fsl
+++ b/tf/shaders/shadows.vert.fsl
@@ -3,7 +3,7 @@ STRUCT(VSInput)
 	DATA(float3, inVertex, POSITION);
 };
 
-CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b1, binding = 1)
+CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b0, binding = 0)
 {
     DATA(float4x4, vpMatrix, None);
 };

--- a/tf/shaders/shadows.vert.fsl
+++ b/tf/shaders/shadows.vert.fsl
@@ -8,9 +8,10 @@ CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b1, binding = 1)
     DATA(float4x4, vpMatrix, None);
 };
 
-PUSH_CONSTANT(uRootConstants, b0)
+PUSH_CONSTANT(rootconstant_model, b2)
 {
     DATA(float4x4, model, None);
+    DATA(float, pad, None);
 };
 
 STRUCT(VSOutput)

--- a/tf/shaders/shadows.vert.fsl
+++ b/tf/shaders/shadows.vert.fsl
@@ -8,7 +8,7 @@ CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b0, binding = 0)
     DATA(float4x4, vpMatrix, None);
 };
 
-PUSH_CONSTANT(rootconstant_model, b2)
+PUSH_CONSTANT(rootconstant_large, b2)
 {
     DATA(float4x4, model, None);
     DATA(float, pad, None);

--- a/tf/shaders/skybox.vert.fsl
+++ b/tf/shaders/skybox.vert.fsl
@@ -4,7 +4,7 @@ STRUCT(VSInput)
     DATA(float2, inTexCoord, TEXCOORD0);
 };
 
-CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b1, binding = 1)
+CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b0, binding = 0)
 {
     DATA(float4x4, vpMatrix, None);
 };

--- a/tf/shaders/skybox.vert.fsl
+++ b/tf/shaders/skybox.vert.fsl
@@ -9,7 +9,7 @@ CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b0, binding = 0)
     DATA(float4x4, vpMatrix, None);
 };
 
-PUSH_CONSTANT(rootconstant_model, b2)
+PUSH_CONSTANT(rootconstant_large, b2)
 {
     DATA(float4x4, model, None);
     DATA(float, pad, None);

--- a/tf/shaders/skybox.vert.fsl
+++ b/tf/shaders/skybox.vert.fsl
@@ -9,7 +9,7 @@ CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b1, binding = 1)
     DATA(float4x4, vpMatrix, None);
 };
 
-CBUFFER(UniformBufferObject_rootcbv, UPDATE_FREQ_PER_DRAW, b0, binding = 0)
+PUSH_CONSTANT(uRootConstants, b0)
 {
     DATA(float4x4, model, None);
 };

--- a/tf/shaders/skybox.vert.fsl
+++ b/tf/shaders/skybox.vert.fsl
@@ -9,9 +9,10 @@ CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b1, binding = 1)
     DATA(float4x4, vpMatrix, None);
 };
 
-PUSH_CONSTANT(uRootConstants, b0)
+PUSH_CONSTANT(rootconstant_model, b2)
 {
     DATA(float4x4, model, None);
+    DATA(float, pad, None);
 };
 
 STRUCT(VSOutput)

--- a/tf/shaders/sprite.vert.fsl
+++ b/tf/shaders/sprite.vert.fsl
@@ -9,7 +9,7 @@ CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b0, binding = 0)
     DATA(float4x4, vpMatrix, None);
 };
 
-PUSH_CONSTANT(uRootConstants, b1)
+PUSH_CONSTANT(rootconstant_small, b1)
 {
     DATA(float, alpha, None);
 };

--- a/tf/shaders/sprite.vert.fsl
+++ b/tf/shaders/sprite.vert.fsl
@@ -4,12 +4,12 @@ STRUCT(VSInput)
     DATA(float2, inTexCoord, TEXCOORD0);
 };
 
-CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b1, binding = 1)
+CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b0, binding = 0)
 {
     DATA(float4x4, vpMatrix, None);
 };
 
-PUSH_CONSTANT(uRootConstants, b0)
+PUSH_CONSTANT(uRootConstants, b1)
 {
     DATA(float, alpha, None);
 };

--- a/tf/shaders/sprite.vert.fsl
+++ b/tf/shaders/sprite.vert.fsl
@@ -9,7 +9,7 @@ CBUFFER(UniformBufferObject, UPDATE_FREQ_PER_FRAME, b1, binding = 1)
     DATA(float4x4, vpMatrix, None);
 };
 
-CBUFFER(UniformBufferObject_rootcbv, UPDATE_FREQ_PER_DRAW, b0, binding = 0)
+PUSH_CONSTANT(uRootConstants, b0)
 {
     DATA(float, alpha, None);
 };

--- a/tf/shaders/world_warp.frag.fsl
+++ b/tf/shaders/world_warp.frag.fsl
@@ -1,11 +1,12 @@
 // Underwater screen warp effect similar to what software renderer provides
 
-PUSH_CONSTANT(PushConstant, b1)
+PUSH_CONSTANT(uRootConstants, b1)
 {
 	DATA(float, time, None);
 	DATA(float, scale, None);
 	DATA(float, scrWidth, None);
 	DATA(float, scrHeight, None);
+	DATA(float4, pad, None);
 };
 
 RES(Tex2D(float4), sTexture, UPDATE_FREQ_NONE, t1, binding = 1);

--- a/tf/shaders/world_warp.frag.fsl
+++ b/tf/shaders/world_warp.frag.fsl
@@ -1,6 +1,6 @@
 // Underwater screen warp effect similar to what software renderer provides
 
-PUSH_CONSTANT(uRootConstants, b1)
+PUSH_CONSTANT(rootconstant_small, b1)
 {
 	DATA(float, time, None);
 	DATA(float, scale, None);

--- a/tf/src/gra_common.cpp
+++ b/tf/src/gra_common.cpp
@@ -91,8 +91,9 @@ Buffer *pBufferRectIbo;
 Buffer *pBufferTriangleFanIBO;
 Buffer *pBufferUniform;
 
-uint32_t gPushConstant;
+uint32_t gPushConstantFloat8;
 uint32_t gPushConstantModel;
+uint32_t gPushConstantPolygonWarp;
 
 static void _addShaders();
 static void _removeShaders();
@@ -453,8 +454,10 @@ bool _addRootSignatures()
     };
 
     addRootSignature(pRenderer, &rootDesc, &pRootSignature);
-    gPushConstant = getDescriptorIndexFromName(pRootSignature, "uRootConstants");
+    gPushConstantFloat8 = getDescriptorIndexFromName(pRootSignature, "uRootConstants");
     gPushConstantModel = getDescriptorIndexFromName(pRootSignature, "rootconstant_model");
+    gPushConstantPolygonWarp = getDescriptorIndexFromName(pRootSignature, "rootconstant_polygonwarp");
+    
     return pRootSignature != NULL;
 }
 
@@ -1202,7 +1205,7 @@ void GRA_DrawColorRect(float *ubo, size_t uboSize, RenderPass rpType)
     const uint32_t stride = sizeof(float) * 2;
 
     cmdBindPipeline(pCmd, drawColorQuadPipeline[static_cast<size_t>(rpType)]);
-    cmdBindPushConstants(pCmd, pRootSignature, gPushConstant, ubo);
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantFloat8, ubo);
     cmdBindVertexBuffer(pCmd, 1, &pBufferColorRectVbo, &stride, 0);
     cmdBindIndexBuffer(pCmd, pBufferRectIbo, INDEX_TYPE_UINT32, 0);
 
@@ -1215,7 +1218,7 @@ void GRA_DrawTexRect(float *ubo, size_t uboSize, image_t *image)
 
     cmdBindPipeline(pCmd, drawTexQuadPipeline);
     
-    cmdBindPushConstants(pCmd, pRootSignature, gPushConstant, ubo);
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantFloat8, ubo);
     cmdBindDescriptorSet(pCmd, 0, pDSTexture[image->index]);
     cmdBindVertexBuffer(pCmd, 1, &pBufferTexRectVbo, &stride, 0);
     cmdBindIndexBuffer(pCmd, pBufferRectIbo, INDEX_TYPE_UINT32, 0);

--- a/tf/src/gra_common.cpp
+++ b/tf/src/gra_common.cpp
@@ -1201,7 +1201,10 @@ void GRA_DrawColorRect(float *ubo, size_t uboSize, RenderPass rpType)
     const uint32_t stride = sizeof(float) * 2;
 
     cmdBindPipeline(pCmd, drawColorQuadPipeline[static_cast<size_t>(rpType)]);
-    GRA_BindUniformBuffer(pCmd, ubo, uboSize);
+    uint32_t mRootConstantIndex = getDescriptorIndexFromName(pRootSignature, "uRootConstants");
+    cmdBindPushConstants(pCmd, pRootSignature, mRootConstantIndex, ubo);
+    
+    //GRA_BindUniformBuffer(pCmd, ubo, uboSize);
     cmdBindVertexBuffer(pCmd, 1, &pBufferColorRectVbo, &stride, 0);
     cmdBindIndexBuffer(pCmd, pBufferRectIbo, INDEX_TYPE_UINT32, 0);
 
@@ -1213,7 +1216,10 @@ void GRA_DrawTexRect(float *ubo, size_t uboSize, image_t *image)
     const uint32_t stride = sizeof(float) * 4;
 
     cmdBindPipeline(pCmd, drawTexQuadPipeline);
-    GRA_BindUniformBuffer(pCmd, ubo, uboSize);
+    //GRA_BindUniformBuffer(pCmd, ubo, uboSize);
+
+    uint32_t mRootConstantIndex = getDescriptorIndexFromName(pRootSignature, "uRootConstants");
+    cmdBindPushConstants(pCmd, pRootSignature, mRootConstantIndex, ubo);
     cmdBindDescriptorSet(pCmd, 0, pDSTexture[image->index]);
     cmdBindVertexBuffer(pCmd, 1, &pBufferTexRectVbo, &stride, 0);
     cmdBindIndexBuffer(pCmd, pBufferRectIbo, INDEX_TYPE_UINT32, 0);

--- a/tf/src/gra_common.cpp
+++ b/tf/src/gra_common.cpp
@@ -452,7 +452,7 @@ bool _addRootSignatures()
     };
 
     addRootSignature(pRenderer, &rootDesc, &pRootSignature);
-    gPushConstant = getDescriptorIndexFromName(pRootSignature, "PushConstant");
+    gPushConstant = getDescriptorIndexFromName(pRootSignature, "uRootConstants");
 
     return pRootSignature != NULL;
 }
@@ -1201,10 +1201,7 @@ void GRA_DrawColorRect(float *ubo, size_t uboSize, RenderPass rpType)
     const uint32_t stride = sizeof(float) * 2;
 
     cmdBindPipeline(pCmd, drawColorQuadPipeline[static_cast<size_t>(rpType)]);
-    uint32_t mRootConstantIndex = getDescriptorIndexFromName(pRootSignature, "uRootConstants");
-    cmdBindPushConstants(pCmd, pRootSignature, mRootConstantIndex, ubo);
-    
-    //GRA_BindUniformBuffer(pCmd, ubo, uboSize);
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstant, ubo);
     cmdBindVertexBuffer(pCmd, 1, &pBufferColorRectVbo, &stride, 0);
     cmdBindIndexBuffer(pCmd, pBufferRectIbo, INDEX_TYPE_UINT32, 0);
 
@@ -1216,10 +1213,8 @@ void GRA_DrawTexRect(float *ubo, size_t uboSize, image_t *image)
     const uint32_t stride = sizeof(float) * 4;
 
     cmdBindPipeline(pCmd, drawTexQuadPipeline);
-    //GRA_BindUniformBuffer(pCmd, ubo, uboSize);
-
-    uint32_t mRootConstantIndex = getDescriptorIndexFromName(pRootSignature, "uRootConstants");
-    cmdBindPushConstants(pCmd, pRootSignature, mRootConstantIndex, ubo);
+    
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstant, ubo);
     cmdBindDescriptorSet(pCmd, 0, pDSTexture[image->index]);
     cmdBindVertexBuffer(pCmd, 1, &pBufferTexRectVbo, &stride, 0);
     cmdBindIndexBuffer(pCmd, pBufferRectIbo, INDEX_TYPE_UINT32, 0);

--- a/tf/src/gra_common.cpp
+++ b/tf/src/gra_common.cpp
@@ -91,8 +91,8 @@ Buffer *pBufferRectIbo;
 Buffer *pBufferTriangleFanIBO;
 Buffer *pBufferUniform;
 
-uint32_t gPushConstantFloat8;
-uint32_t gPushConstantModel;
+uint32_t gPushConstantSmall;
+uint32_t gPushConstantLarge;
 uint32_t gPushConstantPolygonWarp;
 
 static void _addShaders();
@@ -454,8 +454,8 @@ bool _addRootSignatures()
     };
 
     addRootSignature(pRenderer, &rootDesc, &pRootSignature);
-    gPushConstantFloat8 = getDescriptorIndexFromName(pRootSignature, "uRootConstants");
-    gPushConstantModel = getDescriptorIndexFromName(pRootSignature, "rootconstant_model");
+    gPushConstantSmall = getDescriptorIndexFromName(pRootSignature, "rootconstant_small");
+    gPushConstantLarge = getDescriptorIndexFromName(pRootSignature, "rootconstant_large");
     gPushConstantPolygonWarp = getDescriptorIndexFromName(pRootSignature, "rootconstant_polygonwarp");
     
     return pRootSignature != NULL;
@@ -1205,7 +1205,7 @@ void GRA_DrawColorRect(float *ubo, size_t uboSize, RenderPass rpType)
     const uint32_t stride = sizeof(float) * 2;
 
     cmdBindPipeline(pCmd, drawColorQuadPipeline[static_cast<size_t>(rpType)]);
-    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantFloat8, ubo);
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantSmall, ubo);
     cmdBindVertexBuffer(pCmd, 1, &pBufferColorRectVbo, &stride, 0);
     cmdBindIndexBuffer(pCmd, pBufferRectIbo, INDEX_TYPE_UINT32, 0);
 
@@ -1218,7 +1218,7 @@ void GRA_DrawTexRect(float *ubo, size_t uboSize, image_t *image)
 
     cmdBindPipeline(pCmd, drawTexQuadPipeline);
     
-    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantFloat8, ubo);
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantSmall, ubo);
     cmdBindDescriptorSet(pCmd, 0, pDSTexture[image->index]);
     cmdBindVertexBuffer(pCmd, 1, &pBufferTexRectVbo, &stride, 0);
     cmdBindIndexBuffer(pCmd, pBufferRectIbo, INDEX_TYPE_UINT32, 0);

--- a/tf/src/gra_common.cpp
+++ b/tf/src/gra_common.cpp
@@ -92,6 +92,7 @@ Buffer *pBufferTriangleFanIBO;
 Buffer *pBufferUniform;
 
 uint32_t gPushConstant;
+uint32_t gPushConstantModel;
 
 static void _addShaders();
 static void _removeShaders();
@@ -453,7 +454,7 @@ bool _addRootSignatures()
 
     addRootSignature(pRenderer, &rootDesc, &pRootSignature);
     gPushConstant = getDescriptorIndexFromName(pRootSignature, "uRootConstants");
-
+    gPushConstantModel = getDescriptorIndexFromName(pRootSignature, "rootconstant_model");
     return pRootSignature != NULL;
 }
 

--- a/tf/src/gra_common.h
+++ b/tf/src/gra_common.h
@@ -96,8 +96,9 @@ extern Buffer *pBufferColorRectVbo;
 extern Buffer *pBufferRectIbo;
 extern Buffer *pBufferUniform;
 
-extern uint32_t gPushConstant;
+extern uint32_t gPushConstantFloat8;
 extern uint32_t gPushConstantModel;
+extern uint32_t gPushConstantPolygonWarp;
 
 extern ProfileToken gGpuProfileToken;
 

--- a/tf/src/gra_common.h
+++ b/tf/src/gra_common.h
@@ -96,8 +96,8 @@ extern Buffer *pBufferColorRectVbo;
 extern Buffer *pBufferRectIbo;
 extern Buffer *pBufferUniform;
 
-extern uint32_t gPushConstantFloat8;
-extern uint32_t gPushConstantModel;
+extern uint32_t gPushConstantSmall;
+extern uint32_t gPushConstantLarge;
 extern uint32_t gPushConstantPolygonWarp;
 
 extern ProfileToken gGpuProfileToken;

--- a/tf/src/gra_common.h
+++ b/tf/src/gra_common.h
@@ -97,6 +97,7 @@ extern Buffer *pBufferRectIbo;
 extern Buffer *pBufferUniform;
 
 extern uint32_t gPushConstant;
+extern uint32_t gPushConstantModel;
 
 extern ProfileToken gGpuProfileToken;
 

--- a/tf/src/gra_mesh.cpp
+++ b/tf/src/gra_mesh.cpp
@@ -260,7 +260,7 @@ void Vk_DrawAliasFrameLerp(dmdl_t *paliashdr, float backlerp, image_t *skin, flo
         drawInfo[pipelineIdx][pipeCounters[pipelineIdx]].firstVertex = vertCounts[pipelineIdx];
     }
 
-    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantModel, &meshUbo);
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantLarge, &meshUbo);
     // player configuration screen model is using the UI renderpass
     int pidx = (int)(r_newrefdef.rdflags & RDF_NOWORLDMODEL ? RenderPass::UI : RenderPass::WORLD);
     // non-depth write alias models don't occur with RF_WEAPONMODEL set, so no need for additional left-handed pipelines
@@ -341,7 +341,7 @@ void Vk_DrawAliasShadow(dmdl_t *paliashdr, int posenum, float *modelMatrix)
 
     height = -lheight + 1.0;
 
-    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantModel, &modelMatrix);
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantLarge, &modelMatrix);
 
     static vec3_t shadowverts[MAX_VERTS];
     while (1)

--- a/tf/src/gra_mesh.cpp
+++ b/tf/src/gra_mesh.cpp
@@ -260,7 +260,7 @@ void Vk_DrawAliasFrameLerp(dmdl_t *paliashdr, float backlerp, image_t *skin, flo
         drawInfo[pipelineIdx][pipeCounters[pipelineIdx]].firstVertex = vertCounts[pipelineIdx];
     }
 
-    cmdBindPushConstants(pCmd, pRootSignature, gPushConstant, &meshUbo);
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantModel, &meshUbo);
     // player configuration screen model is using the UI renderpass
     int pidx = (int)(r_newrefdef.rdflags & RDF_NOWORLDMODEL ? RenderPass::UI : RenderPass::WORLD);
     // non-depth write alias models don't occur with RF_WEAPONMODEL set, so no need for additional left-handed pipelines
@@ -341,7 +341,7 @@ void Vk_DrawAliasShadow(dmdl_t *paliashdr, int posenum, float *modelMatrix)
 
     height = -lheight + 1.0;
 
-    cmdBindPushConstants(pCmd, pRootSignature, gPushConstant, &modelMatrix);
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantModel, &modelMatrix);
 
     static vec3_t shadowverts[MAX_VERTS];
     while (1)

--- a/tf/src/gra_mesh.cpp
+++ b/tf/src/gra_mesh.cpp
@@ -260,8 +260,7 @@ void Vk_DrawAliasFrameLerp(dmdl_t *paliashdr, float backlerp, image_t *skin, flo
         drawInfo[pipelineIdx][pipeCounters[pipelineIdx]].firstVertex = vertCounts[pipelineIdx];
     }
 
-    GRA_BindUniformBuffer(pCmd, &meshUbo, sizeof(meshUbo));
-
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstant, &meshUbo);
     // player configuration screen model is using the UI renderpass
     int pidx = (int)(r_newrefdef.rdflags & RDF_NOWORLDMODEL ? RenderPass::UI : RenderPass::WORLD);
     // non-depth write alias models don't occur with RF_WEAPONMODEL set, so no need for additional left-handed pipelines
@@ -342,7 +341,7 @@ void Vk_DrawAliasShadow(dmdl_t *paliashdr, int posenum, float *modelMatrix)
 
     height = -lheight + 1.0;
 
-    GRA_BindUniformBuffer(pCmd, &modelMatrix, sizeof(float) * 16);
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstant, &modelMatrix);
 
     static vec3_t shadowverts[MAX_VERTS];
     while (1)

--- a/tf/src/gra_rmain.cpp
+++ b/tf/src/gra_rmain.cpp
@@ -226,7 +226,7 @@ void R_DrawSpriteModel(entity_t *e)
     };
 
     cmdBindPipeline(pCmd, drawSpritePipeline);
-    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantFloat8, &alpha);
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantSmall, &alpha);
     constexpr uint32_t stride = sizeof(float) * 5;
     GRA_BindVertexBuffer(pCmd, quadVerts, sizeof(quadVerts), stride);
 
@@ -292,7 +292,7 @@ void R_DrawNullModel(void)
 
     cmdBindPipeline(pCmd, drawNullModelPipeline);
     cmdBindDescriptorSet(pCmd, 0, pDSUniform);
-    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantModel, &model);
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantLarge, &model);
 
     constexpr uint32_t stride = sizeof(vec3_t);
     GRA_BindVertexBuffer(pCmd, verts, sizeof(verts), stride);
@@ -535,7 +535,7 @@ void R_DrawParticles(void)
         }
 
         cmdBindPipeline(pCmd, drawPointParticlesPipeline);
-        cmdBindPushConstants(pCmd, pRootSignature, gPushConstantFloat8, &particleUbo);
+        cmdBindPushConstants(pCmd, pRootSignature, gPushConstantSmall, &particleUbo);
 
         constexpr uint32_t stride = sizeof(ppoint);
         GRA_BindVertexBuffer(pCmd, visibleParticles, sizeof(ppoint) * r_newrefdef.num_particles, stride);
@@ -825,7 +825,7 @@ void R_EndWorldRenderpass(void)
 
     cmdBeginGpuTimestampQuery(pCmd, gGpuProfileToken, "Game World Water Effect");
 
-    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantFloat8, pushConsts);
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantSmall, pushConsts);
     cmdBindDescriptorSet(pCmd, 0, pDSWorldTexture);
     cmdBindPipeline(pCmd, worldWarpPipeline);
     cmdDraw(pCmd, 3, 0);
@@ -868,7 +868,7 @@ void R_SetVulkan2D(void)
     if (!(r_newrefdef.rdflags & RDF_NOWORLDMODEL))
     {
         float pushConsts[] = {vk_postprocess->value, vid_gamma->value};
-        cmdBindPushConstants(pCmd, pRootSignature, gPushConstantFloat8, pushConsts);
+        cmdBindPushConstants(pCmd, pRootSignature, gPushConstantSmall, pushConsts);
         cmdBindDescriptorSet(pCmd, 0, pDSWorldWarpTexture);
         cmdBindPipeline(pCmd, postprocessPipeline);
         cmdDraw(pCmd, 3, 0);
@@ -1482,7 +1482,7 @@ void R_DrawBeam(entity_t *e)
 
     cmdBindPipeline(pCmd, drawBeamPipeline);
     cmdBindDescriptorSet(pCmd, 0, pDSUniform);
-    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantFloat8, color);
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantSmall, color);
 
     constexpr uint32_t stride = sizeof(float) * 3;
     GRA_BindVertexBuffer(pCmd, beamvertex, sizeof(beamvertex), stride);

--- a/tf/src/gra_rmain.cpp
+++ b/tf/src/gra_rmain.cpp
@@ -226,7 +226,7 @@ void R_DrawSpriteModel(entity_t *e)
     };
 
     cmdBindPipeline(pCmd, drawSpritePipeline);
-    cmdBindPushConstants(pCmd, pRootSignature, gPushConstant, &alpha);
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantFloat8, &alpha);
     constexpr uint32_t stride = sizeof(float) * 5;
     GRA_BindVertexBuffer(pCmd, quadVerts, sizeof(quadVerts), stride);
 
@@ -535,7 +535,7 @@ void R_DrawParticles(void)
         }
 
         cmdBindPipeline(pCmd, drawPointParticlesPipeline);
-        cmdBindPushConstants(pCmd, pRootSignature, gPushConstant, &particleUbo);
+        cmdBindPushConstants(pCmd, pRootSignature, gPushConstantFloat8, &particleUbo);
 
         constexpr uint32_t stride = sizeof(ppoint);
         GRA_BindVertexBuffer(pCmd, visibleParticles, sizeof(ppoint) * r_newrefdef.num_particles, stride);
@@ -825,7 +825,7 @@ void R_EndWorldRenderpass(void)
 
     cmdBeginGpuTimestampQuery(pCmd, gGpuProfileToken, "Game World Water Effect");
 
-    cmdBindPushConstants(pCmd, pRootSignature, gPushConstant, pushConsts);
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantFloat8, pushConsts);
     cmdBindDescriptorSet(pCmd, 0, pDSWorldTexture);
     cmdBindPipeline(pCmd, worldWarpPipeline);
     cmdDraw(pCmd, 3, 0);
@@ -868,7 +868,7 @@ void R_SetVulkan2D(void)
     if (!(r_newrefdef.rdflags & RDF_NOWORLDMODEL))
     {
         float pushConsts[] = {vk_postprocess->value, vid_gamma->value};
-        cmdBindPushConstants(pCmd, pRootSignature, gPushConstant, pushConsts);
+        cmdBindPushConstants(pCmd, pRootSignature, gPushConstantFloat8, pushConsts);
         cmdBindDescriptorSet(pCmd, 0, pDSWorldWarpTexture);
         cmdBindPipeline(pCmd, postprocessPipeline);
         cmdDraw(pCmd, 3, 0);
@@ -1482,7 +1482,7 @@ void R_DrawBeam(entity_t *e)
 
     cmdBindPipeline(pCmd, drawBeamPipeline);
     cmdBindDescriptorSet(pCmd, 0, pDSUniform);
-    cmdBindPushConstants(pCmd, pRootSignature, gPushConstant, color);
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantFloat8, color);
 
     constexpr uint32_t stride = sizeof(float) * 3;
     GRA_BindVertexBuffer(pCmd, beamvertex, sizeof(beamvertex), stride);

--- a/tf/src/gra_rmain.cpp
+++ b/tf/src/gra_rmain.cpp
@@ -226,7 +226,7 @@ void R_DrawSpriteModel(entity_t *e)
     };
 
     cmdBindPipeline(pCmd, drawSpritePipeline);
-    GRA_BindUniformBuffer(pCmd, &alpha, sizeof(alpha));
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstant, &alpha);
     constexpr uint32_t stride = sizeof(float) * 5;
     GRA_BindVertexBuffer(pCmd, quadVerts, sizeof(quadVerts), stride);
 
@@ -292,7 +292,7 @@ void R_DrawNullModel(void)
 
     cmdBindPipeline(pCmd, drawNullModelPipeline);
     cmdBindDescriptorSet(pCmd, 0, pDSUniform);
-    GRA_BindUniformBuffer(pCmd, &model, sizeof(model));
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstant, &model);
 
     constexpr uint32_t stride = sizeof(vec3_t);
     GRA_BindVertexBuffer(pCmd, verts, sizeof(verts), stride);
@@ -535,7 +535,7 @@ void R_DrawParticles(void)
         }
 
         cmdBindPipeline(pCmd, drawPointParticlesPipeline);
-        GRA_BindUniformBuffer(pCmd, &particleUbo, sizeof(particleUbo));
+        cmdBindPushConstants(pCmd, pRootSignature, gPushConstant, &particleUbo);
 
         constexpr uint32_t stride = sizeof(ppoint);
         GRA_BindVertexBuffer(pCmd, visibleParticles, sizeof(ppoint) * r_newrefdef.num_particles, stride);
@@ -1482,7 +1482,7 @@ void R_DrawBeam(entity_t *e)
 
     cmdBindPipeline(pCmd, drawBeamPipeline);
     cmdBindDescriptorSet(pCmd, 0, pDSUniform);
-    GRA_BindUniformBuffer(pCmd, color, sizeof(float) * 4);
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstant, color);
 
     constexpr uint32_t stride = sizeof(float) * 3;
     GRA_BindVertexBuffer(pCmd, beamvertex, sizeof(beamvertex), stride);

--- a/tf/src/gra_rmain.cpp
+++ b/tf/src/gra_rmain.cpp
@@ -292,7 +292,7 @@ void R_DrawNullModel(void)
 
     cmdBindPipeline(pCmd, drawNullModelPipeline);
     cmdBindDescriptorSet(pCmd, 0, pDSUniform);
-    cmdBindPushConstants(pCmd, pRootSignature, gPushConstant, &model);
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantModel, &model);
 
     constexpr uint32_t stride = sizeof(vec3_t);
     GRA_BindVertexBuffer(pCmd, verts, sizeof(verts), stride);

--- a/tf/src/gra_rsurf.cpp
+++ b/tf/src/gra_rsurf.cpp
@@ -129,7 +129,7 @@ void DrawVkPoly(vkpoly_t *p, image_t *texture, vec4 color)
 
     uint32_t stride = sizeof(polyvert);
     GRA_BindVertexBuffer(pCmd, verts, sizeof(polyvert) * p->numverts, stride);
-    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantFloat8, &color);
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantSmall, &color);
 
     auto indexCount = GRA_BindTriangleFanIBO(pCmd, p->numverts);
     cmdDrawIndexed(pCmd, indexCount, 0, 0);
@@ -171,7 +171,7 @@ void DrawVkFlowingPoly(msurface_t *fa, image_t *texture, vec4 color)
     }
 
     cmdBindPipeline(pCmd, drawPolyPipeline);
-    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantFloat8, &color);
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantSmall, &color);
 
     uint32_t stride = sizeof(polyvert);
     GRA_BindVertexBuffer(pCmd, verts, sizeof(polyvert) * p->numverts, stride);
@@ -204,7 +204,7 @@ void R_DrawTriangleOutlines(void)
     } triVert[4];
 
     cmdBindPipeline(pCmd, showTrisPipeline);
-    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantFloat8, color);
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantSmall, color);
 
     for (i = 0; i < MAX_LIGHTMAPS; i++)
     {
@@ -472,7 +472,7 @@ static void Vk_RenderLightmappedPoly(msurface_t *surf, float *modelMatrix, float
 
     cmdBindPipeline(pCmd, drawPolyLmapPipeline);
     cmdBindDescriptorSet(pCmd, 0, pDSUniform);
-    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantModel, &lmapPolyUbo);
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantLarge, &lmapPolyUbo);
 
     for (map = 0; map < MAXLIGHTMAPS && surf->styles[map] != 255; map++)
     {

--- a/tf/src/gra_rsurf.cpp
+++ b/tf/src/gra_rsurf.cpp
@@ -472,7 +472,7 @@ static void Vk_RenderLightmappedPoly(msurface_t *surf, float *modelMatrix, float
 
     cmdBindPipeline(pCmd, drawPolyLmapPipeline);
     cmdBindDescriptorSet(pCmd, 0, pDSUniform);
-    cmdBindPushConstants(pCmd, pRootSignature, gPushConstant, &lmapPolyUbo);
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantModel, &lmapPolyUbo);
 
     for (map = 0; map < MAXLIGHTMAPS && surf->styles[map] != 255; map++)
     {

--- a/tf/src/gra_rsurf.cpp
+++ b/tf/src/gra_rsurf.cpp
@@ -129,7 +129,7 @@ void DrawVkPoly(vkpoly_t *p, image_t *texture, vec4 color)
 
     uint32_t stride = sizeof(polyvert);
     GRA_BindVertexBuffer(pCmd, verts, sizeof(polyvert) * p->numverts, stride);
-    cmdBindPushConstants(pCmd, pRootSignature, gPushConstant, &color);
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantFloat8, &color);
 
     auto indexCount = GRA_BindTriangleFanIBO(pCmd, p->numverts);
     cmdDrawIndexed(pCmd, indexCount, 0, 0);
@@ -171,7 +171,7 @@ void DrawVkFlowingPoly(msurface_t *fa, image_t *texture, vec4 color)
     }
 
     cmdBindPipeline(pCmd, drawPolyPipeline);
-    cmdBindPushConstants(pCmd, pRootSignature, gPushConstant, &color);
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantFloat8, &color);
 
     uint32_t stride = sizeof(polyvert);
     GRA_BindVertexBuffer(pCmd, verts, sizeof(polyvert) * p->numverts, stride);
@@ -204,7 +204,7 @@ void R_DrawTriangleOutlines(void)
     } triVert[4];
 
     cmdBindPipeline(pCmd, showTrisPipeline);
-    cmdBindPushConstants(pCmd, pRootSignature, gPushConstant, color);
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantFloat8, color);
 
     for (i = 0; i < MAX_LIGHTMAPS; i++)
     {

--- a/tf/src/gra_rsurf.cpp
+++ b/tf/src/gra_rsurf.cpp
@@ -129,7 +129,7 @@ void DrawVkPoly(vkpoly_t *p, image_t *texture, vec4 color)
 
     uint32_t stride = sizeof(polyvert);
     GRA_BindVertexBuffer(pCmd, verts, sizeof(polyvert) * p->numverts, stride);
-    GRA_BindUniformBuffer(pCmd, &color, sizeof(vec4));
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstant, &color);
 
     auto indexCount = GRA_BindTriangleFanIBO(pCmd, p->numverts);
     cmdDrawIndexed(pCmd, indexCount, 0, 0);
@@ -171,7 +171,7 @@ void DrawVkFlowingPoly(msurface_t *fa, image_t *texture, vec4 color)
     }
 
     cmdBindPipeline(pCmd, drawPolyPipeline);
-    GRA_BindUniformBuffer(pCmd, &color, sizeof(vec4));
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstant, &color);
 
     uint32_t stride = sizeof(polyvert);
     GRA_BindVertexBuffer(pCmd, verts, sizeof(polyvert) * p->numverts, stride);
@@ -204,7 +204,7 @@ void R_DrawTriangleOutlines(void)
     } triVert[4];
 
     cmdBindPipeline(pCmd, showTrisPipeline);
-    GRA_BindUniformBuffer(pCmd, color, sizeof(float) * 4);
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstant, color);
 
     for (i = 0; i < MAX_LIGHTMAPS; i++)
     {
@@ -472,7 +472,7 @@ static void Vk_RenderLightmappedPoly(msurface_t *surf, float *modelMatrix, float
 
     cmdBindPipeline(pCmd, drawPolyLmapPipeline);
     cmdBindDescriptorSet(pCmd, 0, pDSUniform);
-    GRA_BindUniformBuffer(pCmd, &lmapPolyUbo, sizeof(lmapPolyUbo));
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstant, &lmapPolyUbo);
 
     for (map = 0; map < MAXLIGHTMAPS && surf->styles[map] != 255; map++)
     {

--- a/tf/src/gra_warp.cpp
+++ b/tf/src/gra_warp.cpp
@@ -609,7 +609,7 @@ void R_DrawSkyBox(void)
         cmdBindDescriptorSet(pCmd, 0, pDSUniform);
         cmdBindDescriptorSet(pCmd, 0, pDSTexture[sky_images[skytexorder[i]]->index]);
 
-        cmdBindPushConstants(pCmd, pRootSignature, gPushConstantModel, model);
+        cmdBindPushConstants(pCmd, pRootSignature, gPushConstantLarge, model);
 
         constexpr uint32_t stride = sizeof(polyvert);
         GRA_BindVertexBuffer(pCmd, verts.data(), sizeof(verts), stride);

--- a/tf/src/gra_warp.cpp
+++ b/tf/src/gra_warp.cpp
@@ -247,7 +247,7 @@ void EmitWaterPolys(msurface_t *fa, image_t *texture, float *modelMatrix, vec4 c
 
     cmdBindDescriptorSet(pCmd, 0, pDSUniform);
     cmdBindDescriptorSet(pCmd, 0, pDSTexture[texture->index]);
-    cmdBindPushConstants(pCmd, pRootSignature, gPushConstant, &polyUbo);
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstantPolygonWarp, &polyUbo);
 
     for (bp = fa->polys; bp; bp = bp->next)
     {

--- a/tf/src/gra_warp.cpp
+++ b/tf/src/gra_warp.cpp
@@ -247,7 +247,7 @@ void EmitWaterPolys(msurface_t *fa, image_t *texture, float *modelMatrix, vec4 c
 
     cmdBindDescriptorSet(pCmd, 0, pDSUniform);
     cmdBindDescriptorSet(pCmd, 0, pDSTexture[texture->index]);
-    GRA_BindUniformBuffer(pCmd, &polyUbo, sizeof(polyUbo));
+    cmdBindPushConstants(pCmd, pRootSignature, gPushConstant, &polyUbo);
 
     for (bp = fa->polys; bp; bp = bp->next)
     {
@@ -609,7 +609,7 @@ void R_DrawSkyBox(void)
         cmdBindDescriptorSet(pCmd, 0, pDSUniform);
         cmdBindDescriptorSet(pCmd, 0, pDSTexture[sky_images[skytexorder[i]]->index]);
 
-        GRA_BindUniformBuffer(pCmd, model, sizeof(model));
+        cmdBindPushConstants(pCmd, pRootSignature, gPushConstant, model);
 
         constexpr uint32_t stride = sizeof(polyvert);
         GRA_BindVertexBuffer(pCmd, verts.data(), sizeof(verts), stride);

--- a/tf/src/gra_warp.cpp
+++ b/tf/src/gra_warp.cpp
@@ -609,7 +609,7 @@ void R_DrawSkyBox(void)
         cmdBindDescriptorSet(pCmd, 0, pDSUniform);
         cmdBindDescriptorSet(pCmd, 0, pDSTexture[sky_images[skytexorder[i]]->index]);
 
-        cmdBindPushConstants(pCmd, pRootSignature, gPushConstant, model);
+        cmdBindPushConstants(pCmd, pRootSignature, gPushConstantModel, model);
 
         constexpr uint32_t stride = sizeof(polyvert);
         GRA_BindVertexBuffer(pCmd, verts.data(), sizeof(verts), stride);


### PR DESCRIPTION
I found that when using root constant buffer view with large amount of objects (in this case it's ~5000), some value inside the buffer becomes weird for some reason. That results in missing objects in many places. 

changes to push contant solve this problem, but at cost at more complexity on the handling uniform.